### PR TITLE
Feat/#3 mutex spsc prototype

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,6 +14,12 @@ FastReplay is a C++ library providing a single-producer/single-consumer
 It exposes its internal memory buffer to Python via pybind11's
 buffer protocol to achieve zero-copy data sharing between C++ and Python.
 
+System Requirements
+===================
+* **C++ Standard**: C++11 (For cross-platform compatibility)
+* **CMake**: 3.15+ (Recommended)
+* **Python**: 3.8+ (For pybind11 integration)
+
 Technical Definition
 ====================
 

--- a/include/fastreplay/ring_buffer.hpp
+++ b/include/fastreplay/ring_buffer.hpp
@@ -2,24 +2,75 @@
 #define FAST_REPLAY_RING_BUFFER_HPP
 
 #include <cstddef>
+#include <mutex>
+#include <vector>
 
 namespace fastreplay {
 
 //interface placeholder
 class RingBuffer {
 public:
-    explicit RingBuffer(std::size_t capacity);
-    ~RingBuffer();
+    explicit RingBuffer(std::size_t capacity)
+		: capacity_(capacity)
+		, buf_(capacity + 1) // +1 for full/empty distinguish
+		, head_(0) // set init head/tail to 0
+		, tail_(0) {}
+
+    ~RingBuffer() = default;
+
+    // SPSC queue semantics: non-copyable, non-movable
+    RingBuffer(const RingBuffer&) = delete;
+    RingBuffer& operator=(const RingBuffer&) = delete;
+  
+    // Push a val into buffer. Return true on success, false if full.
+    bool push(int value){
+		std::lock_guard<std::mutex> lock(mtx_);
+		std::size_t next_tail = (tail_ + 1) % (capacity_ + 1);
+		if(next_tail == head_){
+			return false; // full
+		}
+		buf_[tail_] = value;
+		tail_ = next_tail;
+		return true;
+    }
+
+	// Pop a value from buffer. (C++11 pass-by-reference)
+	// Return true on success, false if empty
+	bool pop(int& out_val){
+		std::lock_guard<std::mutex> lock(mtx_);
+		if(head_ == tail_){
+			return false; // empty
+		}
+		out_val = buf_[head_];
+		head_ = (head_ + 1) % (capacity_ + 1);
+		return true;
+	}
+
+	std::size_t size() const {
+		std::lock_guard<std::mutex> lock(mtx_);
+		return (tail_ - head_ + capacity_ + 1) % (capacity_ + 1);
+	}
+
+	bool empty() const {
+		std::lock_guard<std::mutex> lock(mtx_);
+		return head_ == tail_;
+	}
+
+	std::size_t capacity() const {
+		return capacity_;
+	}
 
     /*Week2: push/pop
       Week3: buffer_protocol
       Week4: atomic-based synchronization
     */
 
-    std::size_t capacity() const;
-
 private:
-    std::size_t capacity_;
+    std::size_t capacity_; // user-facing capacity actual store size is capacity +1
+    std::vector<int> buf_; // internal storage (size = capacity + 1)
+    std::size_t head_; // read index
+    std::size_t tail_; // write idx
+    mutable std::mutex mtx_; // week2 mutex-based sync
 };
 
 } 

--- a/tests/test_stub.cpp
+++ b/tests/test_stub.cpp
@@ -1,7 +1,110 @@
 #include <gtest/gtest.h>
 #include "fastreplay/ring_buffer.hpp"
 
+// Using C++11
+
 // w1: only test compile at include
 TEST(SmokeTest, HeaderCompiles) {
     EXPECT_EQ(1, 1);
+}
+
+// ---- Week 2: RingBuffer unit tests ----
+
+TEST(RingBufferTest, ConstructorSetsCapacity) {
+    fastreplay::RingBuffer rb(8);
+    EXPECT_EQ(rb.capacity(), 8);
+}
+
+TEST(RingBufferTest, InitiallyEmpty) {
+    fastreplay::RingBuffer rb(4);
+    EXPECT_EQ(rb.size(), 0);
+    EXPECT_TRUE(rb.empty());
+}
+
+TEST(RingBufferTest, PushAndPop) {
+    fastreplay::RingBuffer rb(4);
+    EXPECT_TRUE(rb.push(42));
+    EXPECT_EQ(rb.size(), 1);
+
+    int val = 0;
+    EXPECT_TRUE(rb.pop(val)); // C++11: pop 回傳 bool，值放在 val
+    EXPECT_EQ(val, 42);
+    EXPECT_EQ(rb.size(), 0);
+}
+
+TEST(RingBufferTest, FIFO_Order) {
+    fastreplay::RingBuffer rb(4);
+    rb.push(10);
+    rb.push(20);
+    rb.push(30);
+
+    int v = 0;
+    EXPECT_TRUE(rb.pop(v));
+    EXPECT_EQ(v, 10);
+    EXPECT_TRUE(rb.pop(v));
+    EXPECT_EQ(v, 20);
+    EXPECT_TRUE(rb.pop(v));
+    EXPECT_EQ(v, 30);
+}
+
+TEST(RingBufferTest, PopFromEmptyReturnsFalse) {
+    fastreplay::RingBuffer rb(4);
+    int v = 0;
+    EXPECT_FALSE(rb.pop(v)); // C++11: 空 buffer 時回傳 false，v 不被寫入
+}
+
+TEST(RingBufferTest, PushToFullReturnsFalse) {
+    // 內部實際 array 大小 = capacity + 1，可用空間 = capacity
+    fastreplay::RingBuffer rb(3);
+    EXPECT_TRUE(rb.push(1));
+    EXPECT_TRUE(rb.push(2));
+    EXPECT_TRUE(rb.push(3));
+    EXPECT_FALSE(rb.push(4)); // full
+}
+
+TEST(RingBufferTest, WrapAround) {
+    fastreplay::RingBuffer rb(3);
+
+    // 填滿 3 格
+    rb.push(1);
+    rb.push(2);
+    rb.push(3);
+
+    // pop 2 格，騰出空間
+    int v = 0;
+    EXPECT_TRUE(rb.pop(v));
+    EXPECT_EQ(v, 1);
+    EXPECT_TRUE(rb.pop(v));
+    EXPECT_EQ(v, 2);
+
+    // push 再填 2 格（此時 tail 會 wrap around）
+    EXPECT_TRUE(rb.push(4));
+    EXPECT_TRUE(rb.push(5));
+
+    // 驗證 FIFO 順序
+    EXPECT_TRUE(rb.pop(v));
+    EXPECT_EQ(v, 3);
+    EXPECT_TRUE(rb.pop(v));
+    EXPECT_EQ(v, 4);
+    EXPECT_TRUE(rb.pop(v));
+    EXPECT_EQ(v, 5);
+    EXPECT_TRUE(rb.empty());
+}
+
+TEST(RingBufferTest, SizeTracksCorrectly) {
+    fastreplay::RingBuffer rb(4);
+    EXPECT_EQ(rb.size(), 0);
+
+    rb.push(1);
+    EXPECT_EQ(rb.size(), 1);
+
+    rb.push(2);
+    EXPECT_EQ(rb.size(), 2);
+
+    int v = 0;
+    rb.pop(v);
+    EXPECT_EQ(rb.size(), 1);
+
+    rb.pop(v);
+    EXPECT_EQ(rb.size(), 0);
 }


### PR DESCRIPTION
## Summary
This PR implements the baseline C++ version of the Single-Producer/Single-Consumer (SPSC) ring buffer, serving as the foundational prototype for upcoming optimizations.

## Changes Included
- Implemented circular queue logic using `std::mutex` and `std::vector` in `ring_buffer.hpp`.
- Adopted the `bool pop(int& out_value)` idiom to handle empty pops cleanly.
- Added 8 GoogleTest test cases in `test_stub.cpp` (covering FIFO, wrap-around, full, and empty boundaries). All 9 C++ tests now pass.
- Updated `README.rst` to explicitly document the C++11 standard requirement for cross-platform compatibility.

(Note: Adopting C++11 also ensures consistency with my academic exam environment, allowing me to maintain a unified coding style and avoid potential confusion between projects.)

Resolves #3

---

## Questions for Reviewers (@yungyuc )

I placed `RingBuffer` methods inline in the `.hpp` for two reason: 
1. For potential inlining on the hot path (`push`/`pop`), which eliminates function call overhead during high-frequency RL data collection.
2. The current logic for these methods is compact, so keeping them in the header is clear.

Since `RingBuffer` is not yet templated, would you prefer I move the implementations to a `.cpp` for better separation, or keep the current header-only approach for performance inlining?
