### PR TITLE
Refactor: address post-merge feedback from #6 regarding pop API

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,9 @@
+BasedOnStyle: Google
+IndentWidth: 4
+TabWidth: 4
+UseTab: Never
+ColumnLimit: 100
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+SortIncludes: false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/include/fastreplay/ring_buffer.hpp
+++ b/include/fastreplay/ring_buffer.hpp
@@ -22,7 +22,6 @@ public:
     RingBuffer(const RingBuffer&) = delete;
     RingBuffer& operator=(const RingBuffer&) = delete;
   
-    // Push a val into buffer. Return true on success, false if full.
     bool push(int value){
 		std::lock_guard<std::mutex> lock(mtx_);
 		std::size_t next_tail = (tail_ + 1) % (capacity_ + 1);
@@ -34,14 +33,14 @@ public:
 		return true;
     }
 
-	// Pop a value from buffer. (C++11 pass-by-reference)
-	// Return true on success, false if empty
-	bool pop(int& out_val){
+	bool pop(int* out_val){
 		std::lock_guard<std::mutex> lock(mtx_);
 		if(head_ == tail_){
 			return false; // empty
 		}
-		out_val = buf_[head_];
+		if(out_val != nullptr){
+			*out_val = buf_[head_];
+		}
 		head_ = (head_ + 1) % (capacity_ + 1);
 		return true;
 	}

--- a/tests/test_stub.cpp
+++ b/tests/test_stub.cpp
@@ -27,7 +27,7 @@ TEST(RingBufferTest, PushAndPop) {
     EXPECT_EQ(rb.size(), 1);
 
     int val = 0;
-    EXPECT_TRUE(rb.pop(val)); // C++11: pop 回傳 bool，值放在 val
+    EXPECT_TRUE(rb.pop(&val)); // C++11: pop 回傳 bool，值放在 val
     EXPECT_EQ(val, 42);
     EXPECT_EQ(rb.size(), 0);
 }
@@ -39,18 +39,18 @@ TEST(RingBufferTest, FIFO_Order) {
     rb.push(30);
 
     int v = 0;
-    EXPECT_TRUE(rb.pop(v));
+    EXPECT_TRUE(rb.pop(&v));
     EXPECT_EQ(v, 10);
-    EXPECT_TRUE(rb.pop(v));
+    EXPECT_TRUE(rb.pop(&v));
     EXPECT_EQ(v, 20);
-    EXPECT_TRUE(rb.pop(v));
+    EXPECT_TRUE(rb.pop(&v));
     EXPECT_EQ(v, 30);
 }
 
 TEST(RingBufferTest, PopFromEmptyReturnsFalse) {
     fastreplay::RingBuffer rb(4);
     int v = 0;
-    EXPECT_FALSE(rb.pop(v)); // C++11: 空 buffer 時回傳 false，v 不被寫入
+    EXPECT_FALSE(rb.pop(&v)); // C++11: 空 buffer 時回傳 false，v 不被寫入
 }
 
 TEST(RingBufferTest, PushToFullReturnsFalse) {
@@ -72,9 +72,9 @@ TEST(RingBufferTest, WrapAround) {
 
     // pop 2 格，騰出空間
     int v = 0;
-    EXPECT_TRUE(rb.pop(v));
+    EXPECT_TRUE(rb.pop(&v));
     EXPECT_EQ(v, 1);
-    EXPECT_TRUE(rb.pop(v));
+    EXPECT_TRUE(rb.pop(&v));
     EXPECT_EQ(v, 2);
 
     // push 再填 2 格（此時 tail 會 wrap around）
@@ -82,11 +82,11 @@ TEST(RingBufferTest, WrapAround) {
     EXPECT_TRUE(rb.push(5));
 
     // 驗證 FIFO 順序
-    EXPECT_TRUE(rb.pop(v));
+    EXPECT_TRUE(rb.pop(&v));
     EXPECT_EQ(v, 3);
-    EXPECT_TRUE(rb.pop(v));
+    EXPECT_TRUE(rb.pop(&v));
     EXPECT_EQ(v, 4);
-    EXPECT_TRUE(rb.pop(v));
+    EXPECT_TRUE(rb.pop(&v));
     EXPECT_EQ(v, 5);
     EXPECT_TRUE(rb.empty());
 }
@@ -102,9 +102,9 @@ TEST(RingBufferTest, SizeTracksCorrectly) {
     EXPECT_EQ(rb.size(), 2);
 
     int v = 0;
-    rb.pop(v);
+    rb.pop(&v);
     EXPECT_EQ(rb.size(), 1);
 
-    rb.pop(v);
+    rb.pop(&v);
     EXPECT_EQ(rb.size(), 0);
 }


### PR DESCRIPTION
### **Description:**

## Objective
This PR addresses the technical feedback provided by @yungyuc in Pull Request #6. The primary **goal** is 

1. Improve the **clarity** and **maintainability** of the RingBuffer API
2. Establish project-wide coding standards.

## Changes
### 1. API Refactoring (C++ Core)
- **Modified** `bool pop(int& out_val)` to `bool pop(int* out_val)` in `ring_buffer.hpp`.
- **Reasoning**: As pointed out in the review, pass-by-pointer makes the output nature of the parameter explicit at the caller site (`rb.pop(&val)`), reducing potential confusion and improving self-documentation.
- **Robustness**: Added a `nullptr` check within `pop` to ensure the program remains **stable** even if a null pointer is provided.

### 2. Coding Standards & Infrastructure
- **Added** `.clang-format`: Established a project-wide formatting policy based on Google Style with a 4-space indentation.
- **Added** `.gitattributes`: Configured automatic line-ending normalization (LF) to improve cross-platform consistency.

### 3. Testing
- **Updated** `tests/test_stub.cpp`: Synchronized all 8 C++ unit tests with the new pointer-based API.
- **Validation**: All 9 C++ tests (1 smoke + 8 unit) passed locally.

## Related Issues
- Follow-up to #6
- Part of **Week 2** development phase.