### PR TITLE
Title: Feat: Python bindings and unit tests for RingBuffer

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,9 @@
+BasedOnStyle: Google
+IndentWidth: 4
+TabWidth: 4
+UseTab: Never
+ColumnLimit: 100
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+SortIncludes: false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/include/fastreplay/ring_buffer.hpp
+++ b/include/fastreplay/ring_buffer.hpp
@@ -22,7 +22,6 @@ public:
     RingBuffer(const RingBuffer&) = delete;
     RingBuffer& operator=(const RingBuffer&) = delete;
   
-    // Push a val into buffer. Return true on success, false if full.
     bool push(int value){
 		std::lock_guard<std::mutex> lock(mtx_);
 		std::size_t next_tail = (tail_ + 1) % (capacity_ + 1);
@@ -34,14 +33,14 @@ public:
 		return true;
     }
 
-	// Pop a value from buffer. (C++11 pass-by-reference)
-	// Return true on success, false if empty
-	bool pop(int& out_val){
+	bool pop(int* out_val){
 		std::lock_guard<std::mutex> lock(mtx_);
 		if(head_ == tail_){
 			return false; // empty
 		}
-		out_val = buf_[head_];
+		if(out_val != nullptr){
+			*out_val = buf_[head_];
+		}
 		head_ = (head_ + 1) % (capacity_ + 1);
 		return true;
 	}

--- a/src/fastreplay.cpp
+++ b/src/fastreplay.cpp
@@ -1,4 +1,5 @@
 #include <pybind11/pybind11.h>
+#include "fastreplay/ring_buffer.hpp"
 
 namespace py = pybind11;
 
@@ -8,4 +9,16 @@ PYBIND11_MODULE(fastreplay, m) {
     m.doc() = "FastReplay: atomic-based SPSC ring buffer for RL";
     m.def("add", &add, "Smoke test function",
         py::arg("a"), py::arg("b"));
+    py::class_<fastreplay::RingBuffer>(m, "RingBuffer")
+        .def(py::init<std::size_t>(), py::arg("capacity"))
+        .def("push", &fastreplay::RingBuffer::push, py::arg("value"))
+        .def("pop", [](fastreplay::RingBuffer& self) -> py::object {
+            int val = 0;
+            if(self.pop(&val)) return py::int_(val);
+            return py::none();
+        })
+        .def("size", &fastreplay::RingBuffer::size)
+        .def("empty", &fastreplay::RingBuffer::empty)
+        .def("capacity", &fastreplay::RingBuffer::capacity);
+
 }

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,13 +1,102 @@
-"""Week 1 smoke test: 確認 pybind11 module 能被 import。"""
+"""Week 2 tests: 驗證 fastreplay 模組與 RingBuffer 功能。"""
 import pytest
+import fastreplay
 
 def test_import():
     """Import fastreplay module."""
-    import fastreplay
+    assert hasattr(fastreplay, "RingBuffer")
     assert hasattr(fastreplay, "add")
 
 def test_add():
     """Smoke test: C++ add() 透過 pybind11 正確回傳。"""
-    import fastreplay
     assert fastreplay.add(2, 3) == 5
+
+# --- week2 Ring Buffer test ---
+
+def test_capacity():
+    rb = fastreplay.RingBuffer(2)
+    assert rb.capacity() == 2
+
+def test_empty():
+    rb = fastreplay.RingBuffer(0)
+    assert rb.empty() == True
+
+def test_size():
+    rb = fastreplay.RingBuffer(4)
+    assert not rb.size()
+
+def test_ringbuffer_create():
+    """
+    RingBuffer constructor test.
+    Test the invariant when rb is constructed
+    """
+    rb = fastreplay.RingBuffer(4)
+    assert rb.capacity() == 4
+    assert rb.size() == 0
+    assert rb.empty()
+
+def test_ringbuffer_push_pop():
+    """RingBuffer push and pop test."""
+    rb = fastreplay.RingBuffer(4)
+    assert rb.push(1) is True
+    assert rb.size() == 1
     
+    val = rb.pop()
+    assert val == 1
+    assert rb.size() == 0
+    assert rb.empty()
+
+def test_ringbuffer_fifo_order():
+    """RingBuffer FIFO order test."""
+    rb = fastreplay.RingBuffer(4)
+    rb.push(10)
+    rb.push(20)
+    rb.push(30)
+    assert rb.pop() == 10
+    assert rb.pop() == 20
+    assert rb.pop() == 30
+    assert rb.empty()
+
+def test_ringbuffer_pop_from_empty():
+    """RingBuffer pop from empty test."""
+    rb = fastreplay.RingBuffer(4)
+    assert rb.pop() is None
+    assert rb.size() == 0
+    assert rb.empty()
+
+def test_ringbuffer_push_to_full():
+    """RingBuffer push to full test."""
+    rb = fastreplay.RingBuffer(3)
+    assert rb.push(1)
+    assert rb.push(2)
+    assert rb.push(3)
+    assert not rb.push(4)
+    assert rb.size() == 3
+
+def test_ringbuffer_wrap_around():
+    """RingBuffer wrap around test."""
+    rb = fastreplay.RingBuffer(3)
+    rb.push(1)
+    rb.push(2)
+    rb.push(3)
+    assert rb.pop() == 1
+    assert rb.pop() == 2
+    rb.push(4)
+    rb.push(5)
+    assert rb.pop() == 3
+    assert rb.pop() == 4
+    assert rb.pop() == 5
+    assert rb.empty()
+
+def test_ringbuffer_size_tracks_correctly():
+    """RingBuffer size tracking test."""
+    rb = fastreplay.RingBuffer(4)
+    assert rb.size() == 0
+    rb.push(1)
+    assert rb.size() == 1
+    rb.push(2)
+    assert rb.size() == 2
+    rb.pop()
+    assert rb.size() == 1
+    rb.pop()
+    assert rb.size() == 0

--- a/tests/test_stub.cpp
+++ b/tests/test_stub.cpp
@@ -27,7 +27,7 @@ TEST(RingBufferTest, PushAndPop) {
     EXPECT_EQ(rb.size(), 1);
 
     int val = 0;
-    EXPECT_TRUE(rb.pop(val)); // C++11: pop 回傳 bool，值放在 val
+    EXPECT_TRUE(rb.pop(&val)); // C++11: pop 回傳 bool，值放在 val
     EXPECT_EQ(val, 42);
     EXPECT_EQ(rb.size(), 0);
 }
@@ -39,18 +39,18 @@ TEST(RingBufferTest, FIFO_Order) {
     rb.push(30);
 
     int v = 0;
-    EXPECT_TRUE(rb.pop(v));
+    EXPECT_TRUE(rb.pop(&v));
     EXPECT_EQ(v, 10);
-    EXPECT_TRUE(rb.pop(v));
+    EXPECT_TRUE(rb.pop(&v));
     EXPECT_EQ(v, 20);
-    EXPECT_TRUE(rb.pop(v));
+    EXPECT_TRUE(rb.pop(&v));
     EXPECT_EQ(v, 30);
 }
 
 TEST(RingBufferTest, PopFromEmptyReturnsFalse) {
     fastreplay::RingBuffer rb(4);
     int v = 0;
-    EXPECT_FALSE(rb.pop(v)); // C++11: 空 buffer 時回傳 false，v 不被寫入
+    EXPECT_FALSE(rb.pop(&v)); // C++11: 空 buffer 時回傳 false，v 不被寫入
 }
 
 TEST(RingBufferTest, PushToFullReturnsFalse) {
@@ -72,9 +72,9 @@ TEST(RingBufferTest, WrapAround) {
 
     // pop 2 格，騰出空間
     int v = 0;
-    EXPECT_TRUE(rb.pop(v));
+    EXPECT_TRUE(rb.pop(&v));
     EXPECT_EQ(v, 1);
-    EXPECT_TRUE(rb.pop(v));
+    EXPECT_TRUE(rb.pop(&v));
     EXPECT_EQ(v, 2);
 
     // push 再填 2 格（此時 tail 會 wrap around）
@@ -82,11 +82,11 @@ TEST(RingBufferTest, WrapAround) {
     EXPECT_TRUE(rb.push(5));
 
     // 驗證 FIFO 順序
-    EXPECT_TRUE(rb.pop(v));
+    EXPECT_TRUE(rb.pop(&v));
     EXPECT_EQ(v, 3);
-    EXPECT_TRUE(rb.pop(v));
+    EXPECT_TRUE(rb.pop(&v));
     EXPECT_EQ(v, 4);
-    EXPECT_TRUE(rb.pop(v));
+    EXPECT_TRUE(rb.pop(&v));
     EXPECT_EQ(v, 5);
     EXPECT_TRUE(rb.empty());
 }
@@ -102,9 +102,9 @@ TEST(RingBufferTest, SizeTracksCorrectly) {
     EXPECT_EQ(rb.size(), 2);
 
     int v = 0;
-    rb.pop(v);
+    rb.pop(&v);
     EXPECT_EQ(rb.size(), 1);
 
-    rb.pop(v);
+    rb.pop(&v);
     EXPECT_EQ(rb.size(), 0);
 }


### PR DESCRIPTION
This PR provides the Python interface for the mutex-based RingBuffer.
Note: This branch builds upon the refactored API in #7.

Changes:
- Added pybind11 class binding for RingBuffer.
- Wrapped C++ `pop(int*)` with a Python-friendly Lambda (returns int/None).
- Implemented 12 pytest cases for comprehensive validation.

Resolves #4
Depends on #7