### PR TITLE
Complete Issue #27: Python micro-benchmark for small-payload throughput & latency.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@ lib/
 # Notes (optional, 看你要不要 track)
 survey/
 Classnote/
-
+benchmarks/literature/
 # Python
 __pycache__/
 *.egg-info/

--- a/README.rst
+++ b/README.rst
@@ -87,6 +87,41 @@ Engineering Infrastructure
 * CI: GitHub Actions (Linux).
 * Analysis: ThreadSanitizer (TSan) to detect data races.
 
+Current API Status
+==================
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 10 65
+
+   * - API
+     - Status
+     - Description
+   * - ``push(value)``
+     - ✅
+     - Per-element FIFO write (mutex-synchronized)
+   * - ``pop()``
+     - ✅
+     - Per-element FIFO read + remove
+   * - ``pop_view(n)``
+     - ✅
+     - Batch FIFO read + remove (zero-copy when contiguous)
+   * - ``buffer_protocol``
+     - ✅
+     - Exposes C++ memory to numpy via ``np.asarray(rb)``
+   * - ``sample(batch_size)``
+     - ❌
+     - Random-access read without removal (off-policy RL)
+   * - ``push_batch(array)``
+     - ❌
+     - Batch write from numpy array (nice-to-have, low priority)
+   * - Template generalization
+     - ❌
+     - Currently ``int`` only; need ``float``, ``uint8`` (Issue #22)
+
+See `benchmarks/README.md <benchmarks/README.md>`_ for performance
+data and architectural implications.
+
 Schedule
 ========
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,158 @@
+# FastReplay Benchmark
+
+## Overview
+
+This benchmark framework evaluates FastReplay's SPSC ring buffer
+performance through a systematic methodology derived from a literature
+survey of the above references and 6 reference implementations:
+**SPSCQueue** [4], **MPMCQueue** (Rigtorp), **cpprb**,
+**Reverb** [2], **EnvPool** [1], and **Tianshou** [3].
+
+The evaluation is structured into two layers (Micro and Macro), each
+with specific metrics, payload configurations, and baseline
+comparisons.
+
+---
+
+## Layer 1: Micro-benchmark (No GPU Required)
+
+Isolate and evaluate the raw data structure performance of FastReplay's
+SPSC ring buffer, independent of neural network inference and training.
+
+### Metrics
+
+| Metric | Source Framework | Definition |
+|---|---|---|
+| **ops/ms** | SPSCQueue (Rigtorp) | Push+Pop operations per millisecond |
+| **ns RTT** | SPSCQueue (Rigtorp) | Round-trip latency via ping-pong pattern |
+| **MB/s** | Reverb (DeepMind) | Memory bandwidth utilization |
+
+*   **ops/ms** directly measures queue logic overhead. SPSCQueue [4]
+    reports 362,723 ops/ms on AMD Ryzen 9 3900X
+    (vs boost::lockfree::spsc 209,877 ops/ms).
+*   **MB/s** identifies whether performance is bounded by queue logic
+    or memory bandwidth. Reverb [2] observed an 11 GB/s ceiling across
+    all payload sizes (Section 5.3), attributable to network bandwidth
+    constraints rather than Reverb itself.
+*   **ns RTT** quantifies the cost of memory barriers
+    (`memory_order_release/acquire`) via a two-queue ping-pong pattern
+    between producer and consumer threads. SPSCQueue [4] reports
+    133 ns RTT on the same hardware.
+
+### Payload Levels
+
+Following Reverb's cross-magnitude methodology (400B–400KB), each
+payload level maps to a real RL environment for practical relevance:
+
+| Level | RL Environment | Obs Dimension | Transition Size |
+|---|---|---|---|
+| **Small** | MuJoCo Ant | 111 floats | ~500 B |
+| **Medium** | MuJoCo Humanoid | 376 floats | ~1.5 KB |
+| **Large** | Atari (preprocessed) | 84×84×4 uint8 | ~28 KB |
+| **XL** | High-res Robotics | 256×256×3 uint8 | ~192 KB |
+
+Cross-magnitude testing distinguishes queue logic overhead (visible at
+Small) from memory bandwidth saturation (visible at XL).
+
+### Dual-Language Strategy
+
+| Language | Purpose | Reference |
+|---|---|---|
+| **Python** (primary) | Measures the user-facing API performance including pybind11 binding and zero-copy overhead | EnvPool, cpprb |
+| **C++** (diagnostic) | Isolates pure queue logic overhead for root-cause analysis | SPSCQueue (Rigtorp) |
+
+Python-first because FastReplay's target users are RL researchers who
+interact exclusively through the Python API. If Python-side benchmarks
+show no improvement, C++-side gains are irrelevant to the end user.
+
+### Baselines
+
+1.  **FastReplay (Mutex)**: Current `ring_buffer.hpp` with
+    `std::lock_guard<std::mutex>` on all operations
+2.  **FastReplay (Mutex + Zero-copy)**: Mutex synchronization with
+    `pop_view()` zero-copy path via pybind11 buffer protocol
+    (current `fastreplay.cpp` implementation)
+3.  **FastReplay (Atomic)**: After Issue #11 (`std::atomic` with
+    `memory_order_release/acquire`, `alignas(64)` false-sharing
+    prevention)
+4.  **FastReplay (Atomic + Zero-copy)**: Full optimized pipeline
+5.  **Pure Numpy baseline**: Python-native pre-allocated array with
+    index tracking (represents the simplest possible implementation)
+
+---
+
+## Layer 2: Macro-benchmark (GPU Required, RTX 4090)
+
+End-to-end training integration following EnvPool's [1] time
+decomposition methodology (Section 4.2, Figure 4).
+
+### Time Decomposition (5 Components)
+
+Adapted from EnvPool's 4-component model for buffer-focused analysis:
+
+1.  **Buffer\_Push\_Time**: `buffer.push(transition)`
+2.  **Buffer\_Sample\_Time**: `buffer.sample(batch_size)`
+3.  **NN\_Forward\_Time**: Policy network inference
+4.  **NN\_Backward\_Time**: Gradient computation and parameter update
+5.  **Other\_Time**: Environment step + GPU↔CPU data transfer
+
+### Metrics
+
+| Metric | Source Framework | Definition |
+|---|---|---|
+| **Buffer Time Proportion** | EnvPool (adapted) | `(Push + Sample) / Total_Time` |
+| **SPS** | EnvPool | Steps Per Second for full training loop |
+| **Episodic Return vs Runtime** | Tianshou + EnvPool | Learning curve vs wall-clock time |
+
+### Test Configuration
+
+*   **Algorithm**: SAC (Off-policy, high replay ratio) to maximize
+    buffer access frequency
+*   **SPI Ratio**: Leveraging Reverb's Sample-to-Insert Ratio concept,
+    set artificially high SPI and large Batch Size (1024+) to shift the
+    bottleneck to the buffer data supply
+*   **Environment**: MuJoCo continuous control tasks
+
+---
+
+## Issue Tracking
+
+*   **Parent**: [#23 Comprehensive Performance Evaluation Framework](https://github.com/alu98753/FastReplay/issues/23)
+*   **Sub-issues**:
+    *   [#27 [Micro/Python] Small-payload throughput & latency](https://github.com/alu98753/FastReplay/issues/27) — **this week**
+    *   [#26 [Micro/C++] Pure queue throughput & RTT](https://github.com/alu98753/FastReplay/issues/26)
+    *   [#25 [Micro] Cross-payload (Medium/Large/XL)](https://github.com/alu98753/FastReplay/issues/25) — after template generalization
+    *   [#24 [Macro] End-to-end time decomposition](https://github.com/alu98753/FastReplay/issues/24) — requires RTX 4090
+
+## Results
+
+*(To be populated after benchmark execution)*
+
+## References
+
+### Academic Papers
+*   [1] Weng, J. et al. (2022). "EnvPool: A Highly Parallel
+    Reinforcement Learning Environment Execution Engine."
+    *NeurIPS 2022, Datasets and Benchmarks Track.*
+    [arXiv:2206.10558](https://arxiv.org/abs/2206.10558)
+    — Local: `benchmarks/literature/envpool.txt`
+*   [2] Cassirer, A. et al. (2021). "Reverb: A Framework for
+    Experience Replay." *arXiv preprint.*
+    [arXiv:2102.04736](https://arxiv.org/abs/2102.04736)
+    — Local: `benchmarks/literature/reverb.txt`
+*   [3] Weng, J. et al. (2022). "Tianshou: A Highly Modularized Deep
+    Reinforcement Learning Library."
+    *Journal of Machine Learning Research (JMLR), 23, 1-6.*
+    [arXiv:2107.14171](https://arxiv.org/abs/2107.14171)
+    — Local: `benchmarks/literature/tianshou.txt`
+
+### Reference Implementations
+*   [4] Rigtorp, E. SPSCQueue: Wait-free and lock-free SPSC queue.
+    [GitHub](https://github.com/rigtorp/SPSCQueue)
+    — Local benchmark: `lib/SPSCQueue/src/SPSCQueueBenchmark.cpp`
+*   EnvPool benchmark script:
+    `lib/envpool/benchmark/test_envpool.py`
+
+## Tools
+
+*   NotebookLM: https://notebooklm.google.com/notebook/79483479-0e39-4b45-afeb-e136dc0688b5

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,4 +1,4 @@
-# FastReplay Benchmark
+# Benchmark
 
 ## Overview
 
@@ -123,10 +123,130 @@ Adapted from EnvPool's 4-component model for buffer-focused analysis:
     *   [#26 [Micro/C++] Pure queue throughput & RTT](https://github.com/alu98753/FastReplay/issues/26)
     *   [#25 [Micro] Cross-payload (Medium/Large/XL)](https://github.com/alu98753/FastReplay/issues/25) — after template generalization
     *   [#24 [Macro] End-to-end time decomposition](https://github.com/alu98753/FastReplay/issues/24) — requires RTX 4090
+*   **Related (discovered via benchmark)**:
+    *   [#22 DictBuffer + Template generalization](https://github.com/alu98753/FastReplay/issues/22)
+    *   **NEW**: `[Feature] C++ sample(batch_size)` — correctness & usability (see Insight 1)
+
+## Current Implementation Status
+
+> **Note**: FastReplay does not yet implement `sample()` or `push_batch()`.
+> See [project README](../README.rst) for current API status.
+> I simulate `sample()` in `benchmarks/scripts/micro_bench.py` using
+> buffer protocol + numpy fancy indexing as a proxy measurement.
 
 ## Results
 
-*(To be populated after benchmark execution)*
+### 1. Small-payload throughput & latency (Issue #27)
+
+Script: `benchmarks/scripts/micro_bench.py`
+Environment: WSL2, 1000 trials, reporting median (min–max).
+
+#### Insight 1: Random Sample(with 1000 trials) — No significant difference
+
+Simulates the real off-policy RL pattern
+(SB3 `sac.py:218`: `replay_buffer.sample(batch_size=256)`).
+
+**How this test works (important context)**:
+FastReplay does not yet have a `sample()` method. To simulate it,
+I use the existing buffer protocol to let numpy read directly from
+FastReplay's C++ memory:
+
+1. **Storage**: FastReplay's C++ `std::vector` (data lives in C++)
+2. **Reading**: `np.asarray(rb)` creates a zero-copy view into C++
+   memory, then numpy fancy indexing gathers 256 random elements.
+
+So the "FastReplay" row below measures: **FastReplay storage + numpy reading**.
+The "Numpy baseline" row measures: **numpy storage + numpy reading**.
+
+| Implementation | Median (ns/call) | Range | samples/ms |
+|---|---:|---|---:|
+| FastReplay (C++ storage + numpy read) | 2,033 | 1,042–11,538 | 125,922 |
+| Numpy baseline (numpy storage + numpy read) | 1,941 | 609–5,711 | 131,891 |
+
+**Difference: ~5%, within measurement noise. Ranges overlap heavily.**
+
+Why? Both use the same numpy fancy indexing to gather data. The
+bottleneck is **memory scatter-gather** — the CPU must visit 256
+random memory locations regardless of who owns the memory.
+
+**This motivates implementing C++ `sample()`**: a native C++ sample()
+would handle both storage AND reading internally, eliminating numpy
+from the read path entirely. More critically, the current
+`np.asarray(rb)[:size]` approach has a **correctness issue**: when
+`head ≠ 0` (after pops), it returns stale data from popped positions,
+because the physical layout no longer matches the logical data order.
+For example:
+
+```
+After push(10,20,30,40,50) then pop() twice:
+  Physical memory: [10, 20, 30, 40, 50]   head=2, size=3
+  Valid data:               [30, 40, 50]   (positions 2,3,4)
+  np.asarray(rb)[:3] returns [10, 20, 30]  ← WRONG (includes popped 10, 20)
+  C++ sample() would know to start at head=2 and return from [30, 40, 50]
+```
+
+C++ `sample()` is needed for correctness and usability, not just
+performance.
+
+---
+
+#### Insight 2: Per-element — pybind11 call overhead dominates
+
+| Operation | FastReplay (Mutex) | Numpy | Ratio |
+|---|---:|---:|---|
+| Push | ~9,500 ops/ms | ~23,000 ops/ms | Numpy 2.4x faster |
+| Pop | ~9,500 ops/ms | ~22,000 ops/ms | Numpy 2.3x faster |
+
+pybind11's per-call overhead ≈ **50 ns** fixed cost. Over 1M calls
+this accumulates significantly. In batch operations (Random Sample,
+Batch FIFO), this cost is amortized to near zero because only 1
+cross-boundary call is made.
+
+**Conclusion**: While FastReplay's `push()` is slower than pure numpy
+due to pybind11 overhead, this overhead (~50ns) is completely
+negligible in real RL loops, where `env.step()` takes 0.08–5 ms
+depending on environment complexity [1, Section 4.2].
+Therefore, optimizing per-element push or adding a `push_batch()`
+API is a **low-priority "nice-to-have"**, not a critical bottleneck.
+
+---
+
+#### Insight 3: Batch FIFO — pop_view zero-copy achieves 16.7 GB/s
+
+| Operation | MB/s | Note |
+|---|---:|---|
+| pop_view (zero-copy) | 16,703 | Near DDR4 bandwidth ceiling |
+| np.copy (data copy) | 1,342 | Requires allocation + memcpy |
+| np.view (ref only) | 521,444 | No data movement (misleading) |
+
+pop_view is **12.4x faster** than np.copy. This validates the
+zero-copy path's value for sequential bulk operations (on-policy
+rollout consumption).
+
+Note: `np.view` does no data movement at all (just creates a pointer
+object), so its MB/s figure is not a meaningful bandwidth measure.
+
+---
+
+### Architectural implications
+
+These results inform the development roadmap:
+
+1.  **C++ `sample(batch_size)` is required** (new Issue [#28]
+    (https://github.com/alu98753/FastReplay/issues/28),
+    depends on #22):
+    Not for performance (bottleneck is memory scatter-gather),
+    but for correctness (head offset handling) and usability
+    (matching SB3/Tianshou API expectations).
+2.  **Batch push API is low priority**:
+    Although 1M individual pybind11 calls are slow, in a real RL
+    loop, `push()` is called once per `env.step()`. The ~50ns overhead
+    is negligible compared to env.step time (0.08–5 ms) [1, Section 4.2].
+3.  **Atomic migration (Issue #11)** will not show improvement in
+    single-threaded random sample. Its value lies in enabling
+    true SPSC concurrent push/sample without lock contention.
+
+
 
 ## References
 

--- a/benchmarks/benchmark_literature_survey.md
+++ b/benchmarks/benchmark_literature_survey.md
@@ -1,0 +1,229 @@
+# FastReplay Benchmark 文獻調查 (Literature Survey)
+
+> 本文件基於 `lib/` 目錄下所有 6 個對標框架的原始碼、論文及技術文件，詳細分析各自的 Benchmark 方法論 (methodology)、指標 (metrics) 與測試條件 (test conditions)，並評估其對 FastReplay 的適用性。
+
+---
+
+## 一、底層佇列庫（純資料結構層）
+
+### 1. SPSCQueue (Rigtorp)
+**來源**：[lib/SPSCQueue/](file:///home/clu98753cs13/course/NSD/FastReplay/lib/SPSCQueue/)
+
+#### Benchmark 方法論
+SPSCQueue 的 Benchmark 分為兩個獨立的測試，設計極為精簡且聚焦：
+
+**測試 A：吞吐量測試 (Throughput Benchmark)**
+- **方法**：一個生產者執行緒連續 `emplace` 10,000,000 個 `int`，一個消費者執行緒連續 `pop`
+- **測量方式**：從第一個 `emplace` 到最後一個 `pop` 被消費完的總時間
+- **指標**：**ops/ms**（每毫秒操作次數）
+- **資料型態**：`int`（4 bytes），刻意使用最小元素以隔離「佇列邏輯開銷」
+
+**測試 B：延遲測試 (Latency / Round-Trip Time Benchmark)**
+- **方法**：兩個佇列 q1, q2 構成一個「乒乓 (Ping-Pong)」通道。Thread A 寫入 q1 → Thread B 從 q1 讀取並寫入 q2 → Thread A 從 q2 讀取
+- **測量方式**：完成 10,000,000 次完整往返的總時間 / 迭代次數
+- **指標**：**ns RTT**（Round-Trip Time，奈秒級往返延遲）
+
+#### 關鍵技術細節
+- **CPU 綁核 (CPU Pinning)**：使用 `pthread_setaffinity_np` 將兩個執行緒分別綁定到指定的 CPU 核心，排除作業系統排程 (scheduling) 造成的測量雜訊
+- **計時器**：使用 `std::chrono::steady_clock`（單調時鐘，不受系統時間調整影響）
+- **對照組**：直接在同一份程式碼中比較 `boost::lockfree::spsc_queue` 與 `folly::ProducerConsumerQueue`
+
+#### 報告結果範例（AMD Ryzen 9 3900X）
+
+| Queue | Throughput (ops/ms) | Latency RTT (ns) |
+|---|---:|---:|
+| SPSCQueue | 362,723 | 133 |
+| boost::lockfree::spsc | 209,877 | 222 |
+| folly::ProducerConsumerQueue | 148,818 | 147 |
+
+> [!IMPORTANT]
+> **對 FastReplay 的適用性**：這是與 FastReplay 最直接對標的 Benchmark 模式。FastReplay 的 Atomic 版本應該能夠使用幾乎完全相同的測試架構，直接對比 Mutex 版本 vs Atomic 版本的 ops/ms 與 ns RTT。唯一需要調整的是將 `int` 替換為更接近 RL 場景的資料大小（如 `float[4]` 模擬 CartPole obs）。
+
+---
+
+### 2. MPMCQueue (Rigtorp)
+**來源**：[lib/MPMCQueue/](file:///home/clu98753cs13/course/NSD/FastReplay/lib/MPMCQueue/)
+
+#### Benchmark 方法論
+MPMCQueue 的 README 中明確標註 Benchmark 尚在 TODO 列表中（`[ ] Add benchmarks`），但其**測試方法論**值得參考：
+
+- **正確性驗證**：單執行緒功能測試（包含建構式/解構式調用正確性）
+- **並發模糊測試 (Fuzz Test)**：多執行緒下驗證所有元素均能正確入列/出列
+
+#### 關鍵技術細節
+- **Ticket-based 實作**：使用 `turn` 變數控制讀寫順序，避免 CAS (Compare-And-Swap) 迴圈的效能退化
+- **False Sharing 防護**：使用 `std::hardware_destructive_interference_size`（C++17）
+
+> [!NOTE]
+> **對 FastReplay 的適用性**：MPMCQueue 的架構過於複雜（多生產者多消費者），不直接適用。但其「多執行緒模糊測試」的正確性驗證思路，可以作為 FastReplay 並發壓力測試的參考模板。
+
+---
+
+## 二、RL Replay Buffer 專用庫
+
+### 3. cpprb (Yamada)
+**來源**：[lib/cpprb/](file:///home/clu98753cs13/course/NSD/FastReplay/lib/cpprb/)
+
+#### Benchmark 方法論
+cpprb 並沒有發表正式的學術論文。其效能宣稱主要來自 GitLab 文件中的「Comparison」頁面（目前已無法存取）。但從其原始碼結構中，可以識別出以下測試策略：
+
+- **單元測試**：[test/](file:///home/clu98753cs13/course/NSD/FastReplay/lib/cpprb/test/) 包含大量 Python 測試（`test_PyReplayBuffer.py` 有 16KB），覆蓋功能正確性
+- **Segment Tree 效能**：[test/segmenttree_bench.cpp](file:///home/clu98753cs13/course/NSD/FastReplay/lib/cpprb/test/segmenttree_bench.cpp) (3.6KB) 專門測試 Prioritized Experience Replay 中 Segment Tree 的操作效能
+- **多進程測試**：`test_mp.py` (16KB) 測試 Python multiprocessing 環境下的 Buffer 行為
+
+#### 推測的關鍵指標（基於原始碼分析）
+- **add/sample 時間**：每次 `add()` 與 `sample()` 的平均耗時
+- **Segment Tree 操作時間**：用於量化 PER (Prioritized Experience Replay) 的額外開銷
+
+> [!TIP]
+> **對 FastReplay 的適用性**：cpprb 的 `segmenttree_bench.cpp` 是一個非常好的 C++ 微觀測試範本。FastReplay 可以參考其結構撰寫 C++ 端的 push/sample 效能測試。然而，cpprb 使用 Mutex（鎖式設計），這正是 FastReplay 試圖超越的對照組。
+
+---
+
+### 4. Reverb (DeepMind)
+**來源**：[lib/reverb/](file:///home/clu98753cs13/course/NSD/FastReplay/lib/reverb/) ｜ 論文：[reverb.txt](file:///home/clu98753cs13/course/NSD/FastReplay/benchmarks/literature/reverb.txt)
+
+#### Benchmark 方法論（論文 Section 5）
+Reverb 的效能評估是所有框架中**最嚴謹且最具系統工程深度**的，設計了兩組獨立的壓力測試：
+
+**測試 A：插入效能 (Inserting Benchmark, Section 5.1)**
+- **方法**：1 到 200 個分散式 client 同時向單一 Reverb server 插入資料
+- **資料特徵**：使用隨機 `float32` 張量（刻意排除壓縮效果），payload 跨越四個數量級：400B, 4KB, 40KB, 400KB
+- **Chunk/Sequence 長度**：設為 1（確保 Items 不共享資料，隔離純 I/O 效能）
+
+**測試 B：取樣效能 (Sampling Benchmark, Section 5.2)**
+- **方法**：與插入測試相同架構，但所有 client 同時取樣
+
+#### 核心指標
+
+| 指標 | 定義 | 數值範例 |
+|---|---|---|
+| **BPS (Bytes Per Second)** | 伺服器每秒處理的總位元組數 | 最高 **11 GB/s**（受網路頻寬限制） |
+| **QPS (Queries Per Second)** | 伺服器每秒處理的 Item 操作數 | 插入 ~60K；取樣 ~600K |
+| **SPI (Sample to Insert Ratio)** | 每插入一筆資料被取樣的次數 | 用於控制梯度更新頻率 |
+
+#### 關鍵發現（直接引用論文）
+1. **Mutex 是插入端的主要瓶頸**：取樣 QPS 比插入 QPS 高出 **10 倍**，原因是取樣端已實作了降低 Table mutex contention 的優化，但插入端尚未實作
+2. **Sharding 驗證**：為了驗證「Mutex 是瓶頸」的假說，作者將負載分散到同一伺服器上的多個 Table，結果插入 QPS 提升了 **~200%**
+3. **BPS 天花板**：11 GB/s 的上限在不同 payload 大小下均一致，強烈暗示 (indicate) 限制來自網路頻寬而非 Reverb 本身
+
+> [!IMPORTANT]
+> **對 FastReplay 的適用性**：
+> - **BPS 指標**：FastReplay 是 In-process（非分散式），因此 BPS 的天花板不是網路，而是**記憶體頻寬 (Memory Bandwidth)**。這個指標需要重新定義為「記憶體搬運速度」
+> - **Mutex Contention 的證明方法**：Reverb 透過 Sharding 實驗來「證明」瓶頸來自 Mutex。FastReplay 可以採用類似的邏輯：直接對比 Mutex 版本 vs Atomic 版本的 QPS，若 Atomic 版本 QPS 顯著提升，即可歸因於 Lock 競爭的消除
+> - **跨 Payload 大小的測試**：必須模仿 Reverb，測試不同資料維度（CartPole 的 4 floats vs Atari 的 84×84 image）
+
+---
+
+## 三、RL 訓練框架層
+
+### 5. EnvPool (Sea AI Lab / Weng et al., 2022)
+**來源**：[lib/envpool/](file:///home/clu98753cs13/course/NSD/FastReplay/lib/envpool/) ｜ 論文：[envpool.txt](file:///home/clu98753cs13/course/NSD/FastReplay/benchmarks/literature/envpool.txt)
+
+#### Benchmark 方法論（論文 Section 4）
+EnvPool 的評估分為兩個層次，與我們先前的 Micro/Macro 分層完美吻合：
+
+**Part 1：純環境模擬 (Pure Environment Simulation, Section 4.1)**
+- **方法**：使用隨機取樣的動作 (randomly sampled actions) 作為輸入，純粹測量環境引擎的模擬速度
+- **硬體配置**：跨越三種規模——Laptop (12 CPU cores)、Workstation (32 cores)、DGX-A100 (256 cores)
+- **環境類型**：Atari Pong（3D 影像，高記憶體佔用）、MuJoCo Ant（1D 向量，低記憶體佔用）
+- **測量方式**：50K 次迭代的平均 FPS，Atari 的 frameskip=4、MuJoCo sub-step=5
+- **指標**：**FPS (Frames Per Second)**
+- **對照組**：For-loop、Subprocess、Sample-Factory、EnvPool (sync/async/numa+async)
+
+**Part 2：端到端訓練 (End-to-End Agent Training, Section 4.2)**
+- **方法**：將 EnvPool 整合進 CleanRL、rl_games、Acme 等現有訓練框架
+- **指標**：
+  1. **Episodic Return vs Frames**（學習曲線，證明 sample efficiency 不受影響）
+  2. **Episodic Return vs Runtime (minutes)**（證明 wall-clock 加速）
+- **時間分解剖析 (Time Decomposition Profiling)**：EnvPool 將每次迭代的總時間拆解為四個組件：
+  1. **Environment Step Time**：`env.step(act)` 的耗時
+  2. **Inference Time**：計算動作、log probability、value 的耗時
+  3. **Training Time**：前向與反向傳播的耗時
+  4. **Other Time**：GPU↔CPU 資料搬移、指標寫入等
+
+#### 關鍵發現
+- 在 Laptop + Atari + N=8 的配置下，環境步進時間從 ~73% 降至 ~10%
+- End-to-end 訓練時間從 200 分鐘降至 73 分鐘
+
+#### 實際 Benchmark 腳本分析
+[benchmark/test_envpool.py](file:///home/clu98753cs13/course/NSD/FastReplay/lib/envpool/benchmark/test_envpool.py) 的實作非常簡潔：
+```python
+t = time.time()
+for _ in tqdm.trange(args.total_step):
+    info = env.recv()[-1]
+    env.send(action, info["env_id"])
+duration = time.time() - t
+fps = total_step * batch_size / duration * frame_skip
+```
+- 使用 `time.time()` 進行 wall-clock 計時
+- FPS 計算公式：`(總步數 × batch_size × frame_skip) / 總秒數`
+
+> [!IMPORTANT]
+> **對 FastReplay 的適用性**：
+> - **時間分解方法論**是 FastReplay 宏觀測試中最重要的參考。FastReplay 不是環境引擎，而是 Buffer，因此我們的時間分解應調整為：
+>   1. `Buffer_Push_Time`：`buffer.push(transition)` 的耗時
+>   2. `Buffer_Sample_Time`：`buffer.sample(batch_size)` 的耗時
+>   3. `NN_Forward_Time`：推論耗時
+>   4. `NN_Backward_Time`：訓練耗時
+>   5. `Other_Time`：環境步進 + GPU↔CPU 搬移
+> - **跨硬體測試**：EnvPool 在 Laptop / Workstation / DGX-A100 三個環境下測試。FastReplay 至少需要在 WSL (CPU-only) 與 RTX 4090 上測試
+
+---
+
+### 6. Tianshou (Weng et al., 2022)
+**來源**：[lib/tianshou/](file:///home/clu98753cs13/course/NSD/FastReplay/lib/tianshou/) ｜ 論文：[tianshou.txt](file:///home/clu98753cs13/course/NSD/FastReplay/benchmarks/literature/tianshou.txt)
+
+#### Benchmark 方法論（論文 Section 2 & Benchmark 網站）
+Tianshou 的 Benchmark **不聚焦於底層效能**，而是聚焦於**演算法正確性與收斂品質**：
+
+- **環境**：OpenAI Gym MuJoCo 任務套件（9 個環境）
+- **演算法**：8 個經典演算法（PPO, SAC, DDPG, TD3 等）
+- **指標**：**Median Performance**（各環境正規化分數的中位數，與 reference implementations 比較）
+- **統計方法**：每個實驗使用 **10 個隨機種子**
+- **目標**：證明 Tianshou 的實作品質，而非底層資料結構的速度
+
+#### 與 Buffer 效能相關的觀察
+Tianshou 論文中**完全沒有**針對 ReplayBuffer 的效能數據。其架構圖（Figure 1）顯示 Buffer 位於「Encapsulation Layer」，被視為基礎設施而非研究亮點。
+
+> [!NOTE]
+> **對 FastReplay 的適用性**：
+> - Tianshou 本身不提供 Buffer 效能數據，但**這正是 FastReplay 的切入點**：證明替換 Tianshou 的 Python ReplayBuffer 為 FastReplay 的 C++ Buffer 後，能獲得可量化的效能增益
+> - Tianshou 的 `Batch` 物件使用 SoA 設計，與 FastReplay 的 `DictBuffer` 架構高度吻合，使整合成本極低
+
+---
+
+## 四、指標對照表：各框架的 Benchmark 設計總覽
+
+| 框架 | 層級 | 主要指標 | 資料型態 | 對照組 | 計時工具 | CPU Pinning |
+|---|---|---|---|---|---|---|
+| **SPSCQueue** | Queue | ops/ms, ns RTT | `int` | boost, folly | `steady_clock` | ✅ |
+| **MPMCQueue** | Queue | *(TODO)* | `int` | *(TODO)* | — | ✅ |
+| **cpprb** | Buffer | add/sample time | RL Transition | Python baseline | *(推測 `time.time`)* | ❌ |
+| **Reverb** | Buffer+Transport | **BPS**, **QPS** | Random float32 (400B–400KB) | 自身不同 client 數 | *(未公開)* | ❌ |
+| **EnvPool** | Env Engine | **FPS** | Atari/MuJoCo frames | Subprocess, Sample-Factory | `time.time` | ✅ (NUMA) |
+| **Tianshou** | Framework | Median Performance | RL episodes | Other RL libs | N/A | ❌ |
+
+---
+
+## 五、FastReplay 應該採用的指標與原因
+
+基於以上調查，FastReplay 的 Benchmark 應建立以下指標體系：
+
+### Micro-benchmark 層（不需 GPU，WSL 可執行）
+
+| 指標 | 來源框架 | 定義 | 為什麼要測 |
+|---|---|---|---|
+| **ops/ms** | SPSCQueue | 每毫秒完成的 push+pop 操作數 | 直接對比 Mutex vs Atomic 的佇列邏輯開銷 |
+| **ns RTT** | SPSCQueue | 單次往返延遲 | 量化 memory barrier 的具體開銷 |
+| **BPS (MB/s)** | Reverb | 每秒搬運的位元組數 | 識別是否達到記憶體頻寬天花板 |
+| **跨 Payload 測試** | Reverb | 在不同資料大小下重複測試 | 區分「佇列邏輯開銷」vs「記憶體搬運開銷」 |
+
+### Macro-benchmark 層（需 GPU，RTX 4090 執行）
+
+| 指標 | 來源框架 | 定義 | 為什麼要測 |
+|---|---|---|---|
+| **Buffer Time Proportion** | EnvPool (改良) | `(Buffer_Push + Buffer_Sample) / Total_Time` | 證明 Buffer 在高速 GPU 下佔據顯著比例 |
+| **SPS (Steps Per Second)** | EnvPool | 每秒完成的完整訓練步數 | End-to-end 效能的最終評判標準 |
+| **時間分解 (Time Decomposition)** | EnvPool | 將每次迭代拆解為 4-5 個組件 | 精確定位效能增益來自何處 |
+| **Episodic Return vs Runtime** | EnvPool + Tianshou | 學習曲線 vs wall-clock 時間 | 證明加速不犧牲 sample efficiency |

--- a/benchmarks/scripts/micro_bench.py
+++ b/benchmarks/scripts/micro_bench.py
@@ -1,0 +1,287 @@
+"""
+Micro-benchmark: Small Payload (int = 4 Bytes)
+Issue #27: [Benchmark/Micro/Python] Small-payload throughput & latency
+
+Metrics (ref: SPSCQueue, Reverb):
+  - ops/ms: operations per millisecond
+  - MB/s:   memory bandwidth utilization
+
+Three test sections:
+  - Per-element: measures single Python->C++ call overhead
+  - Batch FIFO:  measures bulk sequential data transfer (on-policy scenario)
+  - Random Sample: measures off-policy experience replay pattern (SB3/Tianshou)
+     This is the REAL usage pattern for SAC/DQN/TD3.
+     Evidence: SB3 off_policy_algorithm.py:500 (add 1-by-1),
+               SB3 sac.py:218 (sample batch_size=256 via random indexing)
+"""
+import ctypes
+from ctypes import sizeof
+import fastreplay
+import fastreplay_baseline
+import time
+import numpy as np
+
+ITERATIONS = 1_000_000
+CAPACITY = ITERATIONS + 1
+TEST_SIZE = sizeof(ctypes.c_int)  # 4 bytes
+BATCH_SIZE = 256                  # SB3 SAC default
+NUM_SAMPLES = 1000                # number of sample() calls per trial
+NUM_TRIALS = 1000                    # repeat for statistical stability
+
+
+# ============================================================
+# Helpers
+# ============================================================
+
+def warm_up():
+    """Warm up CPU caches and JIT before measurement."""
+    rb = fastreplay.RingBuffer(1024)
+    for i in range(1000):
+        rb.push(i)
+    for i in range(1000):
+        rb.pop()
+
+
+def cal_ops_ms(n, duration_ns):
+    """Calculate operations per millisecond."""
+    return n * 1e6 / duration_ns
+
+
+def cal_mbps(n, duration_ns):
+    """Calculate MB/s throughput.
+
+    n items * sizeof(int) bytes each = total bytes transferred.
+    """
+    total_bytes = n * TEST_SIZE
+    return total_bytes / (duration_ns / 1e9) / 1e6
+
+
+# ============================================================
+# Per-element operations (1M individual calls)
+# ============================================================
+
+def bench_push_per_element(rb, n):
+    """Push n items one by one. Returns elapsed ns."""
+    start = time.perf_counter_ns()
+    for i in range(n):
+        rb.push(i)
+    return time.perf_counter_ns() - start
+
+
+def bench_pop_per_element(rb, n):
+    """Pop n items one by one. Returns elapsed ns."""
+    start = time.perf_counter_ns()
+    for i in range(n):
+        rb.pop()
+    return time.perf_counter_ns() - start
+
+
+def numpy_push_per_element(n):
+    """Numpy baseline: assign n values one by one."""
+    arr = np.zeros(n, dtype=np.int32)
+    start = time.perf_counter_ns()
+    for i in range(n):
+        arr[i] = i
+    return time.perf_counter_ns() - start
+
+
+def numpy_pop_per_element(n):
+    """Numpy baseline: read n values one by one."""
+    arr = np.arange(n, dtype=np.int32)
+    start = time.perf_counter_ns()
+    for i in range(n):
+        _ = arr[i]
+    return time.perf_counter_ns() - start
+
+
+# ============================================================
+# Batch FIFO operations (single bulk call)
+# ============================================================
+
+def bench_pop_view_batch(rb, n):
+    """Pop n items via zero-copy pop_view (single C++ call).
+    Returns elapsed ns.
+    """
+    start = time.perf_counter_ns()
+    _ = rb.pop_view(n)
+    return time.perf_counter_ns() - start
+
+
+def numpy_copy_batch(n):
+    """Numpy baseline: copy n items (actual data movement).
+    Fair comparison for pop_view because both move data.
+    """
+    arr = np.arange(n, dtype=np.int32)
+    start = time.perf_counter_ns()
+    _ = np.copy(arr[:n])
+    return time.perf_counter_ns() - start
+
+
+def numpy_view_batch(n):
+    """Numpy view-only: no data movement, just pointer.
+    NOT a fair comparison — shown for reference only.
+    """
+    arr = np.arange(n, dtype=np.int32)
+    start = time.perf_counter_ns()
+    _ = arr[:n]
+    return time.perf_counter_ns() - start
+
+
+# ============================================================
+# Random Sample (off-policy experience replay)
+#
+# Simulates the REAL usage pattern in SB3 SAC/DQN/TD3:
+#   batch_inds = np.random.randint(0, buffer_size, size=batch_size)
+#   batch = observations[batch_inds]   # fancy indexing
+#
+# FastReplay uses buffer protocol (np.asarray) to expose the
+# underlying C++ array, then numpy fancy indexing to sample.
+# ============================================================
+
+def bench_fastreplay_random_sample(rb, buffer_size, batch_size, num_calls):
+    """Simulate off-policy sample(): random index into buffer via
+    buffer protocol view. Does NOT remove data (read-only).
+    Returns per_call_ns.
+    """
+    # Get zero-copy view of underlying C++ buffer via buffer protocol
+    view = np.asarray(rb)[:buffer_size]
+
+    # Pre-generate random indices (exclude from timing)
+    all_inds = [np.random.randint(0, buffer_size, size=batch_size)
+                for _ in range(num_calls)]
+
+    start = time.perf_counter_ns()
+    for inds in all_inds:
+        _ = view[inds]          # numpy fancy indexing (copies scattered data)
+    elapsed = time.perf_counter_ns() - start
+    return elapsed // num_calls
+
+
+def bench_numpy_random_sample(buffer_size, batch_size, num_calls):
+    """SB3 baseline: pure numpy pre-allocated array + random indexing.
+    This is exactly what SB3 ReplayBuffer.sample() does.
+    """
+    arr = np.arange(buffer_size, dtype=np.int32)
+
+    all_inds = [np.random.randint(0, buffer_size, size=batch_size)
+                for _ in range(num_calls)]
+
+    start = time.perf_counter_ns()
+    for inds in all_inds:
+        _ = arr[inds]
+    elapsed = time.perf_counter_ns() - start
+    return elapsed // num_calls
+
+
+# ============================================================
+# Main
+# ============================================================
+
+def print_row(label, n, duration_ns):
+    """Print a formatted result row."""
+    ops = cal_ops_ms(n, duration_ns)
+    mbps = cal_mbps(n, duration_ns)
+    print(f"  {label:<45s} {ops:>12,.0f} ops/ms  {mbps:>10.2f} MB/s")
+
+
+def print_sample_row(label, ns_list, batch_size):
+    """Print a formatted result row with statistical summary.
+    ns_list: list of per-call ns values from multiple trials.
+    Reports median (min–max) for robustness against WSL noise.
+    """
+    ns_arr = np.array(ns_list)
+    med = int(np.median(ns_arr))
+    lo, hi = int(ns_arr.min()), int(ns_arr.max())
+    samples_per_ms = batch_size * 1e6 / med
+    mbps = batch_size * TEST_SIZE / (med / 1e9) / 1e6
+    print(f"  {label:<40s} {med:>6,} ns/call "
+          f"({lo:,}–{hi:,})  "
+          f"{samples_per_ms:>10,.0f} samples/ms  {mbps:>8.2f} MB/s")
+
+
+def main():
+    warm_up()
+
+    print(f"=== Micro-benchmark: Small Payload "
+          f"(int = {TEST_SIZE} Bytes, N = {ITERATIONS:,}) ===")
+
+    # ----------------------------------------------------------
+    # Random Sample (REAL RL usage pattern) — FIRST
+    # ----------------------------------------------------------
+    print(f"\n--- Random Sample "
+          f"(off-policy replay, batch={BATCH_SIZE}, "
+          f"x{NUM_SAMPLES} calls, {NUM_TRIALS} trials) ---")
+    print(f"  Simulates SB3 SAC: replay_buffer.sample(batch_size=256)")
+
+    # Fill buffer
+    rb_sample = fastreplay.RingBuffer(CAPACITY)
+    for i in range(ITERATIONS):
+        rb_sample.push(i)
+
+    # Collect per-call ns across multiple trials
+    fr_results = []
+    np_results = []
+    for trial in range(NUM_TRIALS):
+        fr_results.append(bench_fastreplay_random_sample(
+            rb_sample, ITERATIONS, BATCH_SIZE, NUM_SAMPLES))
+        np_results.append(bench_numpy_random_sample(
+            ITERATIONS, BATCH_SIZE, NUM_SAMPLES))
+
+    print(f"\n  [sample(batch_size={BATCH_SIZE})]")
+    print_sample_row("FastReplay (buffer_proto + fancy idx)",
+                     fr_results, BATCH_SIZE)
+    print_sample_row("Numpy baseline (SB3 pattern)",
+                     np_results, BATCH_SIZE)
+
+    # ----------------------------------------------------------
+    # Per-element
+    # ----------------------------------------------------------
+    print("\n--- Per-element (1M individual Python->C++ calls) ---")
+
+    # Push
+    print("\n  [Push]")
+    rb_mutex = fastreplay_baseline.RingBuffer(CAPACITY)
+    print_row("FastReplay (Mutex)",
+              ITERATIONS, bench_push_per_element(rb_mutex, ITERATIONS))
+
+    rb_zc = fastreplay.RingBuffer(CAPACITY)
+    print_row("FastReplay (Mutex+ZC)",
+              ITERATIONS, bench_push_per_element(rb_zc, ITERATIONS))
+
+    print_row("Numpy baseline",
+              ITERATIONS, numpy_push_per_element(ITERATIONS))
+
+    # Pop
+    print("\n  [Pop]")
+    print_row("FastReplay (Mutex)",
+              ITERATIONS, bench_pop_per_element(rb_mutex, ITERATIONS))
+
+    print_row("FastReplay (Mutex+ZC)",
+              ITERATIONS, bench_pop_per_element(rb_zc, ITERATIONS))
+
+    print_row("Numpy baseline",
+              ITERATIONS, numpy_pop_per_element(ITERATIONS))
+
+    # ----------------------------------------------------------
+    # Batch FIFO (single call)
+    # ----------------------------------------------------------
+    print("\n--- Batch FIFO (single bulk call for N items) ---")
+
+    # Refill buffer for batch pop test
+    rb_batch = fastreplay.RingBuffer(CAPACITY)
+    for i in range(ITERATIONS):
+        rb_batch.push(i)
+
+    print("\n  [Batch Pop / Slice]")
+    print_row("FastReplay pop_view (zero-copy)",
+              ITERATIONS, bench_pop_view_batch(rb_batch, ITERATIONS))
+
+    print_row("Numpy np.copy(arr[:n]) (data copy)",
+              ITERATIONS, numpy_copy_batch(ITERATIONS))
+
+    print_row("Numpy arr[:n] (view only, ref)",
+              ITERATIONS, numpy_view_batch(ITERATIONS))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Changes
- `benchmarks/scripts/micro_bench.py` (renamed from proposed `micro_bench_python.py`)
- `benchmarks/README.md`: 3 insights with statistical analysis (1000 trials)
- `README.rst`: Current API Status table

## Key Findings
1. **Random Sample**: FastReplay ≈ SB3 numpy baseline (<5% diff).
   Bottleneck is memory scatter-gather, not queue logic.
   Discovered correctness issue → opened #28 for C++ sample().
2. **Per-element**: pybind11 ~50ns overhead, negligible vs env.step (0.08–5ms).
3. **Batch FIFO**: pop_view zero-copy 16.7 GB/s, 12.4x faster than np.copy.

## Not included (as planned)
- Atomic baseline: blocked by #11, will re-run after migration
- File named `micro_bench.py` instead of `micro_bench_python.py`

Closes #27 